### PR TITLE
Refactor inquiries_controller.rb

### DIFF
--- a/inquiries_controller.rb
+++ b/inquiries_controller.rb
@@ -35,7 +35,6 @@ class Gigs::InquiriesController < Gigs::ApplicationController
     @inquiry.artist     = current_profile
     @inquiry.user       = current_profile.main_user
     @inquiry.promoter   = gig.promoter
-    existing_gig_invite = current_profile.gig_invites.where(gig_id: params[:gig_id]).first
 
     #if inquiry is valid, which means we will definitivly after this, copy
     #the riders from the current profile to the inquiry
@@ -69,9 +68,11 @@ class Gigs::InquiriesController < Gigs::ApplicationController
       Gigmit::Intercom::Event::Simple.emit('gig-received-application', gig.promoter_id)
       IntercomCreateOrUpdateUserWorker.perform_async(gig.promoter_id)
 
+      existing_gig_invite = current_profile.gig_invites.find_by(gig_id: params[:gig_id])
       if existing_gig_invite.present?
         Event::Read.emit(:gig_invite, existing_gig_invite.id)
       end
+
       render json: @inquiry, status: :created
     else
       render json: @inquiry.errors, status: :unprocessable_entity

--- a/inquiries_controller.rb
+++ b/inquiries_controller.rb
@@ -36,9 +36,7 @@ class Gigs::InquiriesController < Gigs::ApplicationController
     @inquiry.user       = current_profile.main_user
     @inquiry.promoter   = gig.promoter
 
-    #if inquiry is valid, which means we will definitivly after this, copy
-    #the riders from the current profile to the inquiry
-    if @inquiry.valid?
+    if @inquiry.save
       if current_profile.technical_rider.present? && current_profile.technical_rider.item_hash == params[:inquiry][:technical_rider_hash]
         @inquiry.build_technical_rider(user_id: current_user.id).save!
         MediaItemWorker.perform_async(current_profile.technical_rider.id, @inquiry.technical_rider.id)
@@ -48,9 +46,7 @@ class Gigs::InquiriesController < Gigs::ApplicationController
         @inquiry.build_catering_rider(user_id: current_user.id).save!
         MediaItemWorker.perform_async(current_profile.catering_rider.id, @inquiry.catering_rider.id)
       end
-    end
 
-    if @inquiry.save
       #if profile has no rides yet, which means, this is the profiles first inquiry ever
       #copy the riders from the inquiry to the profile
       if current_profile.technical_rider.blank? && @inquiry.technical_rider.present?

--- a/inquiries_controller.rb
+++ b/inquiries_controller.rb
@@ -7,27 +7,7 @@ class Gigs::InquiriesController < Gigs::ApplicationController
   respond_to :json, only: [:create]
 
   def new
-    @inquiry.gig                   = gig
-    @inquiry.deal_possible_fee_min = gig.deal_possible_fee_min
-    @inquiry.artist_contact        = current_profile.last_inquired(:artist_contact)
-    @inquiry.travel_party_count    = current_profile.last_inquired(:travel_party_count)
-    @inquiry.custom_fields         = gig.custom_fields
-
-    if gig.fixed_fee_option && gig.fixed_fee_max == 0
-      @inquiry.fixed_fee = 0
-    end
-
-    if gig.fixed_fee_negotiable
-      @inquiry.gig.fixed_fee_option = true
-      @inquiry.gig.fixed_fee_max    = 0
-    end
-
-    # set this rider here for new
-    # if user keeps it until create, they will be copied async
-    # otherwise he can pseudo delete the riders in the Inquiry#new form and
-    # add new ones
-    @inquiry.technical_rider = current_profile.technical_rider
-    @inquiry.catering_rider  = current_profile.catering_rider
+    @inquiry.build_from_gig_and_profile(gig, current_profile)
 
     # Gigmit::Matcher#matches? returns a boolean whether an aritst matches a
     # given gig

--- a/inquiries_controller.rb
+++ b/inquiries_controller.rb
@@ -28,24 +28,24 @@ class Gigs::InquiriesController < Gigs::ApplicationController
 
   def create
     if @inquiry.save_with_gig_and_profile(gig, current_profile)
-      if current_profile.technical_rider.present? && current_profile.technical_rider.item_hash == params[:inquiry][:technical_rider_hash]
-        @inquiry.build_technical_rider(user_id: current_user.id).save!
-        MediaItemWorker.perform_async(current_profile.technical_rider.id, @inquiry.technical_rider.id)
-      end
-
-      if current_profile.catering_rider.present? && current_profile.catering_rider.item_hash == params[:inquiry][:catering_rider_hash]
-        @inquiry.build_catering_rider(user_id: current_user.id).save!
-        MediaItemWorker.perform_async(current_profile.catering_rider.id, @inquiry.catering_rider.id)
-      end
-
-      # if profile has no riders yet, which means this is the profile's first inquiry ever
-      # copy the riders from the inquiry to the profile
-      if current_profile.technical_rider.blank? && @inquiry.technical_rider.present?
+      if current_profile.technical_rider.present?
+        if current_profile.technical_rider.item_hash == params[:inquiry][:technical_rider_hash]
+          @inquiry.build_technical_rider(user_id: current_user.id).save!
+          MediaItemWorker.perform_async(current_profile.technical_rider.id, @inquiry.technical_rider.id)
+        end
+      elsif @inquiry.technical_rider.present?
+        # if profile has no riders yet, which means this is the profile's first inquiry ever
+        # copy the riders from the inquiry to the profile
         current_profile.build_technical_rider(user_id: current_user.id).save!
         MediaItemWorker.perform_async(@inquiry.technical_rider.id, current_profile.technical_rider.id)
       end
 
-      if current_profile.catering_rider.blank? && @inquiry.catering_rider.present?
+      if current_profile.catering_rider.present?
+        if current_profile.catering_rider.item_hash == params[:inquiry][:catering_rider_hash]
+          @inquiry.build_catering_rider(user_id: current_user.id).save!
+          MediaItemWorker.perform_async(current_profile.catering_rider.id, @inquiry.catering_rider.id)
+        end
+      elsif @inquiry.catering_rider.present?
         current_profile.build_catering_rider(user_id: current_user.id).save!
         MediaItemWorker.perform_async(@inquiry.catering_rider.id, current_profile.catering_rider.id)
       end

--- a/inquiries_controller.rb
+++ b/inquiries_controller.rb
@@ -112,7 +112,7 @@ class Gigs::InquiriesController < Gigs::ApplicationController
   private
 
   def load_gig
-    @gig = Gig.where(slug: params[:gig_id]).first
+    @gig = Gig.find_by! slug: params[:gig_id]
   end
 
   def paywall_chroot

--- a/inquiries_controller.rb
+++ b/inquiries_controller.rb
@@ -31,12 +31,7 @@ class Gigs::InquiriesController < Gigs::ApplicationController
   end
 
   def create
-    @inquiry.gig        = gig
-    @inquiry.artist     = current_profile
-    @inquiry.user       = current_profile.main_user
-    @inquiry.promoter   = gig.promoter
-
-    if @inquiry.save
+    if @inquiry.save_with_gig_and_profile(gig, current_profile)
       if current_profile.technical_rider.present? && current_profile.technical_rider.item_hash == params[:inquiry][:technical_rider_hash]
         @inquiry.build_technical_rider(user_id: current_user.id).save!
         MediaItemWorker.perform_async(current_profile.technical_rider.id, @inquiry.technical_rider.id)

--- a/inquiry.rb
+++ b/inquiry.rb
@@ -29,4 +29,13 @@ class Inquiry < ActiveRecord::Base
     self.technical_rider = initial_profile.technical_rider
     self.catering_rider  = initial_profile.catering_rider
   end
+
+  def save_with_gig_and_profile(initial_gig, initial_profile)
+    self.gig        = initial_gig
+    self.artist     = initial_profile
+    self.user       = initial_profile.main_user
+    self.promoter   = initial_gig.promoter
+
+    self.save
+  end
 end

--- a/inquiry.rb
+++ b/inquiry.rb
@@ -6,4 +6,27 @@ class Inquiry < ActiveRecord::Base
 
   # ...
 
+  def build_from_gig_and_profile(initial_gig, initial_profile)
+    self.gig                   = initial_gig
+    self.deal_possible_fee_min = initial_gig.deal_possible_fee_min
+    self.artist_contact        = initial_profile.last_inquired(:artist_contact)
+    self.travel_party_count    = initial_profile.last_inquired(:travel_party_count)
+    self.custom_fields         = initial_gig.custom_fields
+
+    if initial_gig.fixed_fee_option && initial_gig.fixed_fee_max == 0
+      self.fixed_fee = 0
+    end
+
+    if gig.fixed_fee_negotiable
+      self.gig.fixed_fee_option = true
+      self.gig.fixed_fee_max    = 0
+    end
+
+    # set this rider here for new
+    # if user keeps it until create, they will be copied async
+    # otherwise he can pseudo delete the riders in the Inquiry#new form and
+    # add new ones
+    self.technical_rider = initial_profile.technical_rider
+    self.catering_rider  = initial_profile.catering_rider
+  end
 end


### PR DESCRIPTION
Hello Marcus and Andreas,
Please find descriptions of my refactoring steps in the commit history of the `refactor` branch.

Here are some additional improvements that may be possible depending on a few things not visible in the pseudo-project like the view for the new action and the full profile model.

1) This block looks like it could be simplified if we could assume that the tax_rate is always dependent on the billing_address.
```ruby
    if current_profile.billing_address.blank? || current_profile.tax_rate.blank?
      @profile = current_profile

      if @profile.billing_address.blank?
        @profile.build_billing_address(name: "#{@profile.main_user.first_name} #{@profile.main_user.last_name}")
      end
    end
```
There is also a method used below to trigger an event that seems similar to the billing_address presence check. Perhaps these two are equivalent?:
```ruby
current_profile.has_a_complete_billing_address? == !(current_profile.billing_address.blank? || current_profile.tax_rate.blank?)
```
Depending on how the instance variable `@profile` is used in the view, it might make sense to assign something like `@billing_address` instead.

---

2) It would be nice to move the rider sync logic out of the controller. Since `current_profile` is assigned to `@inquiry.profile` on create, maybe this could become a member of `Gigmit::Concern::Riders`. I would first like to know what other models share this concern. There may also be a way to remove the reliance on `params[:inquiry][:<rider_rype>_hash]` if riders can be created as a nested association. If that is not possible, maybe a new service / lib object would be a better place to move and test this logic.

---

3) The private method `paywall_chroot` appears to be unused. 
